### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/output/
+vendor/
+#/*/code/


### PR DESCRIPTION
Add  all `vendor/` dirs to `.gitignore`.
Without when we setup the frameworks, exist +4k files to track in Git and it's unmanageable.

Still so, exist ~1k files to track, that complicate to manage the changes.

I think that it will be good to change the dirs structure, like  `/framework-xx/code/`  (code, bench, ... you can choose).
So we can add to `.gitignore` too `/*/code/` and we will manage the changes only in the important files. 
At the same time is easier to delete (clean.sh) and we don't need the temporal dir `temp` in _benchmark to later copy the files.