### PR TITLE
Fix clean with public dir to the microframeworks 

### DIFF
--- a/fastroute-1.3/_benchmark/clean.sh
+++ b/fastroute-1.3/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/fatfree-3.8.1/_benchmark/clean.sh
+++ b/fatfree-3.8.1/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/leaf-3.3/_benchmark/clean.sh
+++ b/leaf-3.3/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/phroute-2.2/_benchmark/clean.sh
+++ b/phroute-2.2/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/siler-1.7.9/_benchmark/clean.sh
+++ b/siler-1.7.9/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/slim-3.12/_benchmark/clean.sh
+++ b/slim-3.12/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete

--- a/slim-4.11/_benchmark/clean.sh
+++ b/slim-4.11/_benchmark/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm -rf !("_benchmark"|"Controllers"|"composer.json"|"index.php")
+rm -rf !("_benchmark"|"Controllers"|"composer.json"|"public")
 find -path './.*' -delete


### PR DESCRIPTION
After added the public dir, when we `clean.sh`, delete the `public/`.

