### PR TITLE
Add apache dockerfile

### DIFF
--- a/.docker/apache.dockerfile
+++ b/.docker/apache.dockerfile
@@ -10,3 +10,7 @@ RUN docker-php-ext-install intl
 
 # Optional opcache (recommended)
 #RUN docker-php-ext-install opcache
+
+ENV PORT 80
+ENTRYPOINT []
+CMD sed -i "s/80/$PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf && docker-php-entrypoint apache2-foreground

--- a/.docker/apache.dockerfile
+++ b/.docker/apache.dockerfile
@@ -1,0 +1,8 @@
+FROM php:8.2-apache
+
+RUN apt-get update \
+    && apt-get install -y libicu-dev
+
+RUN mkdir /var/www/html/PHP-Frameworks-Bench
+
+RUN docker-php-ext-install intl

--- a/.docker/apache.dockerfile
+++ b/.docker/apache.dockerfile
@@ -5,4 +5,8 @@ RUN apt-get update \
 
 RUN mkdir /var/www/html/PHP-Frameworks-Bench
 
+# Need it in a lot of frameworks
 RUN docker-php-ext-install intl
+
+# Optional opcache (recommended)
+#RUN docker-php-ext-install opcache

--- a/apache.sh
+++ b/apache.sh
@@ -10,5 +10,6 @@ PORT=${1:-8080}
 docker build --tag bench/apache -f .docker/apache.dockerfile .
 
 echo "Runing apache in http://127.0.0.1:$PORT"
+echo -e "Press Ctrl+C to stop. \n\n"
 
 docker run -it -p "$PORT":80 -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest

--- a/apache.sh
+++ b/apache.sh
@@ -5,8 +5,10 @@ if [ ! `which docker` ]; then
     exit 1;
 fi
 
+PORT=${1:-8080}
+
 docker build --tag bench/apache -f .docker/apache.dockerfile .
 
-echo "Runing apache in http://127.0.0.1:8080"
+echo "Runing apache in http://127.0.0.1:$PORT"
 
-docker run -it -p 8080:80 -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest
+docker run -it -p "$PORT":80 -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest

--- a/apache.sh
+++ b/apache.sh
@@ -12,4 +12,4 @@ docker build --tag bench/apache -f .docker/apache.dockerfile .
 echo "Runing apache in http://127.0.0.1:$PORT"
 echo -e "Press Ctrl+C to stop. \n\n"
 
-docker run -it -p "$PORT":80 -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest
+docker run -it --net=host -e PORT="$PORT" -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest

--- a/apache.sh
+++ b/apache.sh
@@ -1,0 +1,5 @@
+docker build --tag bench/apache -f .docker/apache.dockerfile .
+
+echo "Runing apache in http://127.0.0.1:8080"
+
+docker run -it -p 8080:80 -v "$PWD":/var/www/html/PHP-Frameworks-Bench:rw bench/apache:latest

--- a/apache.sh
+++ b/apache.sh
@@ -1,3 +1,10 @@
+#!/bin/sh
+
+if [ ! `which docker` ]; then
+    echo "docker not found."
+    exit 1;
+fi
+
 docker build --tag bench/apache -f .docker/apache.dockerfile .
 
 echo "Runing apache in http://127.0.0.1:8080"

--- a/base/_functions.sh
+++ b/base/_functions.sh
@@ -40,8 +40,7 @@ benchmark () {
 
     rps=`grep "Requests/sec:" "$output_wrk" | tr -cd '0-9.'`
 
-    echo "rps: "
-    numfmt --g "$rps"
+    echo "rps: $rps"
 
     # to make a small gap between the WRK and CURL
     sleep 1


### PR DESCRIPTION
I don't use apache for a lot of years ago.
And I don't want to install it only for the bench and less in port 80, and perhaps more people have the same situation.

**Advantages of use Docker:**
- We don't need apache installed in our computer
- Not necessary to copy, chown or change apache config
- Use default php:8.2-apache
- We can change to any PHP version easily in the dockerfile
- Don't pollute the hard disk with logs
- Instant display of errors and logs (easier for developers)
- It's optional, you can use your apache instead

First I needed to fix the permissions nightmare, thanks to the docker.
Still I didn't run any benchmark :(, only `check.sh`. Perhaps tonight I will run this benchmark :smile: .

PD: it's in dir `.docker` because I have another with nginx.


Work in progress!