### PR TITLE
Github Actions tests update to PHP 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install Apache mod_php
       run: |
           LC_ALL=C.UTF-8 sudo apt-add-repository http://ppa.launchpad.net/ondrej/php/ubuntu
-          sudo apt install libapache2-mod-php8.2
-          sudo a2enmod php8.2 rewrite
+          sudo apt install libapache2-mod-php8.3
+          sudo a2enmod php8.3 rewrite
       shell: bash
     
     - name: Setup frameworks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,9 @@ jobs:
   setup:
     name: Check PHP frameworks
     runs-on: ubuntu-22.04
-    
+    env:
+      TERM: xterm-color
+
     steps:
     
     - uses: actions/checkout@v3
@@ -28,9 +30,7 @@ jobs:
       shell: bash
     
     - name: Setup frameworks
-      run: |
-        export TERM=xterm-color
-        bash setup.sh
+      run: bash setup.sh
 
     - name: Copy files to web root
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.2
+        php-version: 8.3
         extensions: dom, curl, libxml, mbstring, zip, pcntl, ctype, iconv, intl
         coverage: none
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ jobs:
   setup:
     name: Check PHP frameworks
     runs-on: ubuntu-22.04
-    env:
-      TERM: xterm-color
 
     steps:
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
       shell: bash
     
     - name: Setup frameworks
-      run: bash setup.sh
+      run: |
+        export TERM=xterm-color
+        bash setup.sh
 
     - name: Copy files to web root
       run: |

--- a/cakephp-4.5/_benchmark/setup.sh
+++ b/cakephp-4.5/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist cakephp/app:4.5.* ./_benchmark/temp
+composer create-project --prefer-dist cakephp/app:4.5.* ./_benchmark/temp --ansi
 yes|mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
@@ -9,5 +9,5 @@ yes|cp -r _benchmark/cakephp/* ./
 
 # some enhancements
 composer dump-autoload -o
-composer install --no-interaction --no-dev -o
+composer install --no-interaction --no-dev -o --ansi
 rm ./webroot/.htaccess

--- a/cakephp-5.0/_benchmark/setup.sh
+++ b/cakephp-5.0/_benchmark/setup.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
-# force color output in Github actions
-export TERM=xterm-color
-
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist cakephp/app:5.0.* ./_benchmark/temp
+composer create-project --ansi --prefer-dist cakephp/app:5.0.* ./_benchmark/temp
 yes|mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller

--- a/cakephp-5.0/_benchmark/setup.sh
+++ b/cakephp-5.0/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --ansi --prefer-dist cakephp/app:5.0.* ./_benchmark/temp
+composer create-project --prefer-dist cakephp/app:5.0.* ./_benchmark/temp --ansi
 yes|mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
@@ -9,5 +9,5 @@ yes|cp -r _benchmark/cakephp/* ./
 
 # some enhancements
 composer dump-autoload -o
-composer install --no-interaction --no-dev -o
+composer install --no-interaction --no-dev -o --ansi
 rm ./webroot/.htaccess

--- a/cakephp-5.0/_benchmark/setup.sh
+++ b/cakephp-5.0/_benchmark/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# force color output in Github actions
+export TERM=xterm-color
+
 # create project
 rm -rf _benchmark/temp
 composer create-project --prefer-dist cakephp/app:5.0.* ./_benchmark/temp

--- a/codeigniter-4.4/_benchmark/setup.sh
+++ b/codeigniter-4.4/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project codeigniter4/appstarter:^4.4 --no-dev ./_benchmark/temp
+composer create-project codeigniter4/appstarter:^4.4 --ansi --no-dev ./_benchmark/temp
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller

--- a/fastroute-1.3/_benchmark/setup.sh
+++ b/fastroute-1.3/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/fatfree-3.8/_benchmark/setup.sh
+++ b/fatfree-3.8/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/fuelphp-1.9/_benchmark/setup.sh
+++ b/fuelphp-1.9/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project fuel/fuel:^1.9.0 --prefer-dist ./_benchmark/temp
+composer create-project fuel/fuel:^1.9.0 --prefer-dist ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
@@ -9,5 +9,5 @@ yes|cp -r _benchmark/fuel/* ./
 
 # some enhancements
 composer config allow-plugins.composer/installers true
-composer install --no-dev -o
+composer install --no-dev -o --ansi
 rm ./public/.htaccess

--- a/kumbia-1.1/_benchmark/setup.sh
+++ b/kumbia-1.1/_benchmark/setup.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist kumbia/framework:1.1.* ./_benchmark/temp
+composer create-project --prefer-dist kumbia/framework:1.1.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -r _benchmark/kumbia/* ./
 
 # some enhancements
-composer install --no-dev --optimize-autoloader
+composer install --no-dev --optimize-autoloader --ansi
 
 find . -name \*.htaccess -type f -delete

--- a/laravel-10.2/_benchmark/setup.sh
+++ b/laravel-10.2/_benchmark/setup.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist laravel/laravel:10.2.* ./_benchmark/temp
+composer create-project --prefer-dist laravel/laravel:10.2.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -rf _benchmark/laravel/. ./
 
 # some enhancements
-composer install --optimize-autoloader --no-dev
+composer install --optimize-autoloader --no-dev --ansi
 chmod -R o+w storage
 
 rm ./public/.htaccess

--- a/leaf-3.5/_benchmark/setup.sh
+++ b/leaf-3.5/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/lumen-10.0/_benchmark/setup.sh
+++ b/lumen-10.0/_benchmark/setup.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist laravel/lumen:10.0.* ./_benchmark/temp
+composer create-project --prefer-dist laravel/lumen:10.0.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -rf _benchmark/lumen/. ./
 
 # some enhancements
-composer install --no-dev -o
+composer install --no-dev -o --ansi
 chmod -R o+w storage
 rm ./public/.htaccess

--- a/phroute-2.2/_benchmark/setup.sh
+++ b/phroute-2.2/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/setup.sh
+++ b/setup.sh
@@ -28,8 +28,7 @@ fi
 for fw in $param_targets
 do
     if [ -d "$fw" ]; then
-        echo ""
-        echo ""
+        echo "\n\n"
         echo "/------- $fw: setting up -------/"
         cd "$fw"
         . "_benchmark/setup.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -28,8 +28,7 @@ fi
 for fw in $param_targets
 do
     if [ -d "$fw" ]; then
-        echo "\n\n"
-        echo "/------- $fw: setting up -------/"
+        printf "\n\n/------- $fw: setting up -------/"
         cd "$fw"
         . "_benchmark/setup.sh"
         cd ..

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,8 @@ fi
 for fw in $param_targets
 do
     if [ -d "$fw" ]; then
+        echo ""
+        echo ""
         echo "/------- $fw: setting up -------/"
         cd "$fw"
         . "_benchmark/setup.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export TERM=xterm-color
 
 if [ ! `which composer` ]; then
     echo "composer not found."

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ fi
 for fw in $param_targets
 do
     if [ -d "$fw" ]; then
-        printf "\n\n"
+        echo -e "\n\n"
         echo "/------- $fw: setting up -------/"
         cd "$fw"
         . "_benchmark/setup.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,8 @@ fi
 for fw in $param_targets
 do
     if [ -d "$fw" ]; then
-        printf "\n\n/------- $fw: setting up -------/"
+        printf "\n\n"
+        echo "/------- $fw: setting up -------/"
         cd "$fw"
         . "_benchmark/setup.sh"
         cd ..

--- a/silex-2.3/_benchmark/setup.sh
+++ b/silex-2.3/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/slim-4.12/_benchmark/setup.sh
+++ b/slim-4.12/_benchmark/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-composer install --no-dev -o
+composer install --no-dev -o --ansi

--- a/symfony-5.4/_benchmark/setup.sh
+++ b/symfony-5.4/_benchmark/setup.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project symfony/skeleton:5.4.* ./_benchmark/temp
+composer create-project symfony/skeleton:5.4.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -r _benchmark/symfony/* ./
 
 # some enhancements
-composer dump-env prod
+composer dump-env prod --ansi
 APP_ENV=prod APP_DEBUG=0 bin/console cache:clear
-composer install --no-dev --optimize-autoloader
+composer install --no-dev --optimize-autoloader --ansi
 chmod -R o+w var

--- a/symfony-6.4/_benchmark/setup.sh
+++ b/symfony-6.4/_benchmark/setup.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project symfony/skeleton:6.4.* ./_benchmark/temp
+composer create-project symfony/skeleton:6.4.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -r _benchmark/symfony/* ./
 
 # some enhancement
-composer dump-env prod
+composer dump-env prod --ansi
 APP_ENV=prod APP_DEBUG=0 bin/console cache:clear
-composer install --no-dev --optimize-autoloader
+composer install --no-dev --optimize-autoloader --ansi
 chmod -R o+w var

--- a/ubiquity-2.4.x.dev/_benchmark/setup.sh
+++ b/ubiquity-2.4.x.dev/_benchmark/setup.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project phpmv/ubiquity-project:2.4.x-dev ./_benchmark/temp
+composer create-project phpmv/ubiquity-project:2.4.x-dev ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
 yes|cp -rf _benchmark/ubiquity/. ./
 
 # some enhancements
-composer install --no-dev --optimize-autoloader
+composer install --no-dev --optimize-autoloader --ansi
 rm ./public/.htaccess

--- a/yii-2.0-basic/_benchmark/setup.sh
+++ b/yii-2.0-basic/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # create project
 rm -rf _benchmark/temp
-composer create-project --prefer-dist yiisoft/yii2-app-basic:2.0.* ./_benchmark/temp
+composer create-project --prefer-dist yiisoft/yii2-app-basic:2.0.* ./_benchmark/temp --ansi
 mv ./_benchmark/temp/{.,}* ./
 
 # have the route & controller
@@ -11,4 +11,4 @@ yes|cp -r _benchmark/yii2/* ./
 # composer install --no-dev -o
 # I used --ignore-platform-req=php because at the moment
 # yii 2 basic not support php 8.2 
-composer --ignore-platform-req=php install --no-dev -o
+composer --ignore-platform-req=php install --no-dev -o --ansi


### PR DESCRIPTION
Update tests to use PHP 8.3 and mod_php 8.3.

To show the composer color output inside a bash in GA, we need to add in the setup.sh the composer option `--ansi`
### Before
![image](https://github.com/myaaghubi/PHP-Frameworks-Bench/assets/249085/548066dd-28c8-473c-bb0d-4cc9303711a0)

### After
![image](https://github.com/myaaghubi/PHP-Frameworks-Bench/assets/249085/af93d815-0b8a-4258-96d4-4a407a51ed3d)
