### PR TITLE
Better error in check.sh

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -34,6 +34,7 @@ do
         fi
     else
         # if exist in config, but not exist the dir
+        echo -e "${RED}❌ don't exist dir for $fw ${NC}"
         FAIL=1
     fi
 done

--- a/check.sh
+++ b/check.sh
@@ -34,7 +34,7 @@ do
         fi
     else
         # if exist in config, but not exist the dir
-        echo -e "${RED}❌ don't exist dir for $fw ${NC}"
+        echo -e "${RED}❌ Dir $fw ${NC} doesn't exist"
         FAIL=1
     fi
 done

--- a/check.sh
+++ b/check.sh
@@ -32,6 +32,9 @@ do
         else
             printf "%-34b %4s bytes   %s\n" "${GREEN}✔ $fw ${NC}" "${#url_output}" "$url"
         fi
+    else
+        # if exist in config, but not exist the dir
+        FAIL=1
     fi
 done
 

--- a/config
+++ b/config
@@ -35,4 +35,5 @@ symfony-6.4
 symfony-7.0
 ubiquity-2.4.x.dev
 yii-2.0-basic
+noframework-1.0
 "

--- a/config
+++ b/config
@@ -35,5 +35,4 @@ symfony-6.4
 symfony-7.0
 ubiquity-2.4.x.dev
 yii-2.0-basic
-noframework-1.0
 "


### PR DESCRIPTION
If exist in config, but it not exist the dir it will send error.

Before I updated frameworks, without change the config, and discarded the frameworks without any error.

Now show error:
![image](https://github.com/myaaghubi/PHP-Frameworks-Bench/assets/249085/13319079-71a6-44f3-be83-e74e2aa33cac)
